### PR TITLE
Automatically escape resource argument in constructor

### DIFF
--- a/lib/azure/signature.rb
+++ b/lib/azure/signature.rb
@@ -9,7 +9,7 @@ module Azure
   # The Signature class encapsulates an canonicalized resource string.
   class Signature
     # The version of the azure-signature library.
-    VERSION = '0.2.1'
+    VERSION = '0.2.2'
 
     # The resource (URL) passed to the constructor.
     attr_reader :resource
@@ -35,9 +35,11 @@ module Azure
     # as an argument and a storage account key. The +resource+ will typically
     # be an Azure storage account endpoint.
     #
+    # Note that the +resource+ is automatically escaped.
+    #
     def initialize(resource, key)
-      @resource = resource
-      @uri = Addressable::URI.parse(resource)
+      @resource = Addressable::URI.escape(resource)
+      @uri = Addressable::URI.parse(@resource)
       @account_name = @uri.host.split(".").first.split("-").first
       @key = Base64.strict_decode64(key)
       @canonical_resource = canonicalize_resource(@uri)

--- a/test/test_signature.rb
+++ b/test/test_signature.rb
@@ -9,7 +9,7 @@ class TC_Azure_Signature < Test::Unit::TestCase
   end
 
   test "version constant is set to expected value" do
-    assert_equal("0.2.1", Azure::Signature::VERSION)
+    assert_equal("0.2.2", Azure::Signature::VERSION)
   end
 
   test "key method basic functionality" do
@@ -75,6 +75,14 @@ class TC_Azure_Signature < Test::Unit::TestCase
     @sig = Azure::Signature.new(@url, @key)
     expected = "/myaccount/mycontainer/myblob"
     assert_equal(expected, @sig.canonical_resource)
+  end
+
+  test "constructor automatically escapes resource argument" do
+    @url = "https://myaccount-secondary.blob.core.windows.net/mycontainer/myblob-{12345}"
+    @sig = Azure::Signature.new(@url, @key)
+    expected = "/myaccount/mycontainer/myblob-%7B12345%7D"
+    assert_equal("/myaccount/mycontainer/myblob-%7B12345%7D", @sig.canonical_resource)
+    assert_equal("https://myaccount-secondary.blob.core.windows.net/mycontainer/myblob-%7B12345%7D", @sig.resource)
   end
 
   test "constructor requires two arguments" do


### PR DESCRIPTION
This PR modifies the constructor so that it automatically escapes the resource argument to the constructor in order to handle special characters like "{}" properly.

Helps solve https://bugzilla.redhat.com/show_bug.cgi?id=1346034
