### PR TITLE
Use activesupport gem

### DIFF
--- a/azure-signature.gemspec
+++ b/azure-signature.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files = ['README', 'CHANGES', 'MANIFEST']
    
   gem.add_dependency('addressable')
-  gem.add_dependency('activesupport')
+  gem.add_dependency('activesupport', '>= 4.2.2')
   gem.add_development_dependency('test-unit')
 
   gem.description = <<-EOF

--- a/azure-signature.gemspec
+++ b/azure-signature.gemspec
@@ -2,7 +2,7 @@ require 'rubygems'
 
 Gem::Specification.new do |gem|
   gem.name      = 'azure-signature'
-  gem.version   = '0.2.3'
+  gem.version   = '0.3.0'
   gem.author    = 'Daniel J. Berger'
   gem.license   = 'Apache 2.0'
   gem.email     = 'djberg96@gmail.com'
@@ -14,6 +14,7 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files = ['README', 'CHANGES', 'MANIFEST']
    
   gem.add_dependency('addressable')
+  gem.add_dependency('activesupport')
   gem.add_development_dependency('test-unit')
 
   gem.description = <<-EOF

--- a/lib/azure/signature.rb
+++ b/lib/azure/signature.rb
@@ -9,7 +9,7 @@ module Azure
   # The Signature class encapsulates an canonicalized resource string.
   class Signature
     # The version of the azure-signature library.
-    VERSION = '0.3.0'
+    VERSION = '0.3.0'.freeze
 
     # The resource (URL) passed to the constructor.
     attr_reader :resource

--- a/lib/azure/signature.rb
+++ b/lib/azure/signature.rb
@@ -26,6 +26,8 @@ module Azure
     # A URI object that encapsulates the resource.
     attr_reader :uri
 
+    attr_accessor :storage_services_version
+
     alias url resource
     alias canonical_url canonical_resource
 
@@ -43,6 +45,7 @@ module Azure
       @account_name = @uri.host.split(".").first.split("-").first
       @key = Base64.strict_decode64(key)
       @canonical_resource = canonicalize_resource(@uri)
+      @storage_services_version = '2016-05-31'
     end
 
     # Generate a signature for use with the table service. Use the +options+
@@ -96,7 +99,7 @@ module Azure
     # - :auth_type. Either 'SharedKey' (the default) or 'SharedKeyLight'.
     # - :verb. The http verb used for SharedKey auth. The default is 'GET'.
     # - :x_ms_date. The x-ms-date used. The default is Time.now.httpdate.
-    # - :x_ms_version. The x-ms-version used. The default is '2015-02-21'.
+    # - :x_ms_version. The x-ms-version used. The default is '2016-05-31'.
     # - :auth_string. If true, prepends the auth_type + account name to the
     #    result and returns a string. The default is false.
     #
@@ -131,7 +134,7 @@ module Azure
     #
     #  sig  = Signature.new(url, key)
     #  date = Time.now.httpdate
-    #  vers = '2015-02-21'
+    #  vers = '2016-05-31'
     #
     #  headers = {
     #    'x-ms-date'    => date,
@@ -165,7 +168,7 @@ module Azure
       end
 
       headers['x-ms-date'] ||= headers['date'] || Time.now.httpdate
-      headers['x-ms-version'] ||= '2015-02-21'
+      headers['x-ms-version'] ||= headers['version'] || storage_services_version
 
       if auth_type == 'SharedKeyLight'
         headers['date'] ||= headers['x-ms-date'] || Time.now.httpdate

--- a/test/test_signature.rb
+++ b/test/test_signature.rb
@@ -9,7 +9,7 @@ class TC_Azure_Signature < Test::Unit::TestCase
   end
 
   test "version constant is set to expected value" do
-    assert_equal("0.2.3", Azure::Signature::VERSION)
+    assert_equal("0.3.0", Azure::Signature::VERSION)
   end
 
   test "key method basic functionality" do


### PR DESCRIPTION
This adds a dependency on the activesupport gem. Mostly I'm after the handy core extensions. Specifically I wanted `Hash#transform_keys` because right now there is some redundancy in the generated headers. Consequently I bumped the version to 0.3.0 (from 0.2.3).

This PR also fixes a potential issue with `auth-type` not getting picked up properly in the `blob_signature` method.

I also updated the default storage services version to 2016-05-31, and created an accessor for it that allows users to set their own date if they wish.